### PR TITLE
Add star schema marts

### DIFF
--- a/models/marts/dim/dim_customers.sql
+++ b/models/marts/dim/dim_customers.sql
@@ -1,0 +1,16 @@
+with
+    base as (
+        select
+            customer_external_id as customer_id,
+            company,
+            country,
+            state,
+            city,
+            zip,
+            lead_created_at,
+            free_trial_started_at
+        from {{ ref("stg_customers") }}
+    )
+
+select *, free_trial_started_at - lead_created_at as days_to_free_trial
+from base

--- a/models/marts/dim/dim_plans.sql
+++ b/models/marts/dim/dim_plans.sql
@@ -1,0 +1,7 @@
+select
+    plan_external_id as plan_id,
+    plan_name,
+    interval_count,
+    interval_unit,
+    interval_count || ' ' || interval_unit as plan_interval
+from {{ ref("stg_plans") }}

--- a/models/marts/fct/fct_invoice_line_items.sql
+++ b/models/marts/fct/fct_invoice_line_items.sql
@@ -1,0 +1,27 @@
+select
+    invoice_external_id as invoice_id,
+    external_id as line_item_id,
+    subscription_external_id,
+    subscription_set_external_id,
+    type,
+    amount_in_cents,
+    plan as plan_id,
+    service_period_start,
+    service_period_end,
+    quantity,
+    proration,
+    discount_code,
+    discount_amount,
+    tax_amount,
+    description,
+    transaction_fee,
+    account_code,
+    transaction_fees_currency,
+    discount_description,
+    event_order,
+    balance_transfer,
+    proration_type,
+    amount_in_cents
+    - coalesce(discount_amount, 0)
+    + coalesce(tax_amount, 0) as net_amount_in_cents
+from {{ ref("stg_invoice_line_items") }}

--- a/models/marts/fct/fct_invoices.sql
+++ b/models/marts/fct/fct_invoices.sql
@@ -1,0 +1,38 @@
+with
+    invoices as (select * from {{ ref("stg_invoices") }}),
+    line_items as (
+        select
+            invoice_external_id,
+            count(*) as line_item_count,
+            sum(amount_in_cents) as total_amount_in_cents,
+            sum(discount_amount) as total_discount_in_cents,
+            sum(tax_amount) as total_tax_in_cents
+        from {{ ref("stg_invoice_line_items") }}
+        group by invoice_external_id
+    ),
+    transactions as (
+        select
+            invoice_external_id,
+            count(*) as total_transactions,
+            sum(
+                case when transaction_result = 'successful' then 1 else 0 end
+            ) as successful_transactions
+        from {{ ref("stg_transactions") }}
+        group by invoice_external_id
+    )
+select
+    i.invoice_external_id as invoice_id,
+    i.customer_external_id as customer_id,
+    i.invoiced_date,
+    i.due_date,
+    i.currency,
+    li.line_item_count,
+    li.total_amount_in_cents,
+    li.total_discount_in_cents,
+    li.total_tax_in_cents,
+    tr.total_transactions,
+    tr.successful_transactions,
+    null as days_until_due
+from invoices i
+left join line_items li on i.invoice_external_id = li.invoice_external_id
+left join transactions tr on i.invoice_external_id = tr.invoice_external_id

--- a/models/marts/fct/fct_manual_subscriptions.sql
+++ b/models/marts/fct/fct_manual_subscriptions.sql
@@ -1,0 +1,14 @@
+select
+    external_id as manual_subscription_event_id,
+    subscription_external_id,
+    customer_external_id as customer_id,
+    plan_external_id as plan_id,
+    date as event_date,
+    effective_date,
+    event_type,
+    currency,
+    amount_in_cents,
+    quantity,
+    report_cash_flow,
+    effective_date - date as days_until_effective
+from {{ ref("stg_manual_subscriptions") }}

--- a/models/marts/fct/fct_subscription_events.sql
+++ b/models/marts/fct/fct_subscription_events.sql
@@ -1,0 +1,14 @@
+select
+    external_id as subscription_event_id,
+    customer_external_id as customer_id,
+    subscription_external_id,
+    event_type,
+    retracted_event_id,
+    date as event_date,
+    effective_date,
+    plan_external_id as plan_id,
+    currency,
+    amount_in_cents,
+    quantity,
+    effective_date - date as days_until_effective
+from {{ ref("stg_subscription_events") }}

--- a/models/marts/fct/fct_transactions.sql
+++ b/models/marts/fct/fct_transactions.sql
@@ -1,0 +1,8 @@
+select
+    transaction_external_id as transaction_id,
+    invoice_external_id as invoice_id,
+    transaction_type,
+    transaction_result,
+    transaction_date,
+    (transaction_result = 'successful')::boolean as was_successful
+from {{ ref("stg_transactions") }}

--- a/models/marts/marts.yml
+++ b/models/marts/marts.yml
@@ -1,0 +1,90 @@
+version: 2
+
+models:
+  - name: dim_customers
+    description: Dimension table for customers with basic attributes and analytics features.
+    columns:
+      - name: customer_id
+        description: Primary key for customers.
+        tests:
+          - not_null
+          - unique
+      - name: days_to_free_trial
+        description: Days between lead creation and start of free trial.
+
+  - name: dim_plans
+    description: Dimension table for subscription plans.
+    columns:
+      - name: plan_id
+        description: Primary key for plans.
+        tests:
+          - not_null
+          - unique
+      - name: plan_interval
+        description: Concatenated interval count and unit.
+
+  - name: fct_invoices
+    description: Fact table summarizing invoice information and totals.
+    columns:
+      - name: invoice_id
+        description: Primary key for invoices.
+        tests:
+          - not_null
+          - unique
+      - name: customer_id
+        description: Foreign key to dim_customers.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+      - name: days_until_due
+        description: Difference between due_date and invoiced_date.
+
+  - name: fct_invoice_line_items
+    description: Fact table of invoice line items with net amount calculation.
+    columns:
+      - name: line_item_id
+        description: Identifier of the line item if present.
+      - name: invoice_id
+        description: Foreign key to fct_invoices.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('fct_invoices')
+              field: invoice_id
+
+  - name: fct_manual_subscriptions
+    description: Manual subscription events.
+    columns:
+      - name: manual_subscription_event_id
+        description: Primary key for manual subscription events.
+        tests:
+          - not_null
+          - unique
+
+  - name: fct_subscription_events
+    description: Subscription events.
+    columns:
+      - name: subscription_event_id
+        description: Primary key for subscription events.
+        tests:
+          - not_null
+          - unique
+
+  - name: fct_transactions
+    description: Transactions for invoices.
+    columns:
+      - name: transaction_id
+        description: Primary key for transactions.
+        tests:
+          - not_null
+          - unique
+      - name: invoice_id
+        description: Foreign key to fct_invoices.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('fct_invoices')
+              field: invoice_id
+


### PR DESCRIPTION
## Summary
- build star schema marts for OLAP use
- create dimension models for customers and plans
- create fact models for invoices, line items, manual subscriptions, subscription events and transactions
- add corresponding schema tests

## Testing
- `uv run sqlfmt models/`
- `uv run dbt build --select marts`
